### PR TITLE
Version - 1.5.4

### DIFF
--- a/EvoMSA/__init__.py
+++ b/EvoMSA/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-__version__ = '1.5.3'
+__version__ = '1.5.4'
 
 try:
     from EvoMSA.evodag import BoW, TextRepresentations, StackGeneralization

--- a/EvoMSA/evodag.py
+++ b/EvoMSA/evodag.py
@@ -279,7 +279,7 @@ class TextRepresentations(BoW):
                                                    for m in self.text_representations)
             _ = np.array(models).T
             if self._unit_vector:
-                return _ / np.atleast_2d(np.linalg.norm(_)).T
+                return _ / np.atleast_2d(np.linalg.norm(_, axis=1)).T
             else:
                 return _
         assert len(D) and isinstance(D[0], dict)
@@ -293,7 +293,7 @@ class TextRepresentations(BoW):
                 models.append(np.array(_).T)
         _ = self._mixer_func(models)
         if self._unit_vector:
-            return _ / np.atleast_2d(np.linalg.norm(_)).T
+            return _ / np.atleast_2d(np.linalg.norm(_, axis=1)).T
         else:
             return _
 

--- a/EvoMSA/tests/test_evodag.py
+++ b/EvoMSA/tests/test_evodag.py
@@ -233,10 +233,10 @@ def test_TextRepresentations_unit():
                                     keyword=False,
                                     n_jobs=1,
                                     unit_vector=True)
-    X = text_repr.transform(['buenos días'])
+    X = text_repr.transform(['buenos días', 'adios'])
     
     _ = np.sqrt((X ** 2).sum(axis=1))
-    np.testing.assert_almost_equal(_, 1)
+    np.testing.assert_almost_equal(_, np.array([1, 1]))
     text_repr = TextRepresentations(lang='es', 
                                     emoji=False,
                                     keyword=False,


### PR DESCRIPTION
It includes the parameter unit vector in `TextRepresentations.` The previous version had a bug. This fixes that bug.